### PR TITLE
Fix bug in WithMaxGoroutines.

### DIFF
--- a/options.go
+++ b/options.go
@@ -79,6 +79,9 @@ func WithMaxGoroutines(max int) BlockOption {
 	return func(n *nursery) {
 		if max < 0 {
 			panic("max goroutine option must be a non negative integer")
+		} else if max == 0 {
+			n.limiter = nil
+			return
 		}
 
 		// +1 because block function is a routine also.


### PR DESCRIPTION
The docstring for `WithMaxGoroutines` states that 0 means no limit, but it doesn't actually reset the limiter to `nil`.