### PR TITLE
Extend tests to get 100% statement coverage; show test coverage in push workflow

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,7 +18,9 @@ jobs:
         uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v24
       - name: Test
-        run: nix develop --command go test -v ./...
+        run: |
+          nix develop --command go test -coverprofile=c.out -v ./...
+          nix develop --command go tool cover -func=c.out
 
   lint:
     name: Lint

--- a/nursery_test.go
+++ b/nursery_test.go
@@ -2,6 +2,7 @@ package conc
 
 import (
 	"context"
+	"errors"
 	"io"
 	"sync"
 	"testing"
@@ -248,6 +249,238 @@ func TestNursery(t *testing.T) {
 		}
 		if !errIsIoEOF {
 			t.Fatalf("error handler provided error isn't io.EOF")
+		}
+	})
+
+	t.Run("BlockReturnsError", func(t *testing.T) {
+		expectedErr := errors.New("block error")
+		err := Block(func(n Nursery) error {
+			return expectedErr
+		})
+		if err != expectedErr {
+			t.Fatalf("expected error %v, got %v", expectedErr, err)
+		}
+	})
+
+	t.Run("LimiterWithContextCancel", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+
+		blockCh := make(chan struct{})
+		doneCh := make(chan struct{})
+
+		err := Block(func(n Nursery) error {
+			// Fill the limiter to capacity with a long-running goroutine
+			n.Go(func() error {
+				close(blockCh)
+				<-doneCh
+				return nil
+			})
+
+			<-blockCh
+			cancel()
+
+			// Try to add another goroutine - this should hit the context.Done() case
+			// since the limiter is full and the context is canceled
+			n.Go(func() error {
+				t.Fatal("this goroutine should not run")
+				return nil
+			})
+
+			close(doneCh)
+			return nil
+		}, WithMaxGoroutines(1), WithContext(ctx))
+
+		if err != nil {
+			t.Error(err)
+		}
+	})
+
+	t.Run("WithTimeout", func(t *testing.T) {
+		start := time.Now()
+		err := Block(func(n Nursery) error {
+			select {
+			case <-time.After(time.Second):
+				t.Fatal("timeout not triggered")
+			case <-n.Done():
+				// Expected path
+			}
+			return nil
+		}, WithTimeout(10*time.Millisecond))
+
+		if err != nil {
+			t.Error(err)
+		}
+
+		if time.Since(start) > 100*time.Millisecond {
+			t.Fatal("timeout not effective")
+		}
+	})
+
+	t.Run("WithDeadline", func(t *testing.T) {
+		start := time.Now()
+		deadline := time.Now().Add(10 * time.Millisecond)
+
+		err := Block(func(n Nursery) error {
+			select {
+			case <-time.After(time.Second):
+				t.Fatal("deadline not triggered")
+			case <-n.Done():
+				// Expected path
+			}
+			return nil
+		}, WithDeadline(deadline))
+
+		if err != nil {
+			t.Error(err)
+		}
+
+		if time.Since(start) > 100*time.Millisecond {
+			t.Fatal("deadline not effective")
+		}
+	})
+
+	t.Run("WithCollectErrors", func(t *testing.T) {
+		var collectedErrors []error
+		expectedErr1 := errors.New("error 1")
+		expectedErr2 := errors.New("error 2")
+
+		err := Block(func(n Nursery) error {
+			n.Go(func() error {
+				return expectedErr1
+			})
+			n.Go(func() error {
+				return expectedErr2
+			})
+			return nil
+		}, WithCollectErrors(&collectedErrors))
+
+		if err != nil {
+			t.Error(err)
+		}
+
+		if len(collectedErrors) != 2 {
+			t.Fatalf("expected 2 errors, got %d", len(collectedErrors))
+		}
+
+		// Check that both errors are in the collection
+		// (order may vary due to concurrency)
+		foundErr1 := false
+		foundErr2 := false
+		for _, err := range collectedErrors {
+			if err == expectedErr1 {
+				foundErr1 = true
+			}
+			if err == expectedErr2 {
+				foundErr2 = true
+			}
+		}
+
+		if !foundErr1 || !foundErr2 {
+			t.Fatalf("not all expected errors were collected: %v", collectedErrors)
+		}
+	})
+
+	t.Run("WithIgnoreErrors", func(t *testing.T) {
+		err := Block(func(n Nursery) error {
+			n.Go(func() error {
+				return errors.New("this error should be ignored")
+			})
+			return nil
+		}, WithIgnoreErrors())
+
+		if err != nil {
+			t.Fatalf("expected nil error with WithIgnoreErrors, got: %v", err)
+		}
+	})
+
+	t.Run("WithMaxGoroutines/Zero", func(t *testing.T) {
+		start := time.Now()
+		err := Block(func(n Nursery) error {
+			for i := 0; i < 3; i++ {
+				n.Go(func() error {
+					time.Sleep(10 * time.Millisecond)
+					return nil
+				})
+			}
+			return nil
+		}, WithMaxGoroutines(0))
+
+		if err != nil {
+			t.Error(err)
+		}
+
+		// With no limit, all goroutines should run concurrently
+		if time.Since(start) >= 30*time.Millisecond {
+			t.Fatal("goroutines not running concurrently with zero limit")
+		}
+	})
+
+	t.Run("WithMaxGoroutines/Negative", func(t *testing.T) {
+		defer func() {
+			r := recover()
+			if r == nil {
+				t.Fatal("expected panic with negative max goroutines")
+			}
+			if r != "max goroutine option must be a non negative integer" {
+				t.Fatalf("unexpected panic message: %v", r)
+			}
+		}()
+
+		_ = Block(func(n Nursery) error {
+			return nil
+		}, WithMaxGoroutines(-1))
+
+		t.Fatal("should have panicked")
+	})
+}
+
+func TestGoroutinePanic(t *testing.T) {
+	t.Run("String", func(t *testing.T) {
+		gp := GoroutinePanic{
+			Value: "test panic",
+			Stack: "test stack",
+		}
+
+		str := gp.String()
+		if str != "test panic\ntest stack" {
+			t.Fatalf("unexpected String() result: %s", str)
+		}
+	})
+
+	t.Run("Error", func(t *testing.T) {
+		gp := GoroutinePanic{
+			Value: "test panic",
+			Stack: "test stack",
+		}
+
+		errStr := gp.Error()
+		if errStr != "test panic\ntest stack" {
+			t.Fatalf("unexpected Error() result: %s", errStr)
+		}
+	})
+
+	t.Run("Unwrap/WithError", func(t *testing.T) {
+		originalErr := errors.New("original error")
+		gp := GoroutinePanic{
+			Value: originalErr,
+			Stack: "test stack",
+		}
+
+		unwrapped := gp.Unwrap()
+		if unwrapped != originalErr {
+			t.Fatalf("expected unwrapped error to be %v, got %v", originalErr, unwrapped)
+		}
+	})
+
+	t.Run("Unwrap/WithNonError", func(t *testing.T) {
+		gp := GoroutinePanic{
+			Value: "not an error",
+			Stack: "test stack",
+		}
+
+		unwrapped := gp.Unwrap()
+		if unwrapped != nil {
+			t.Fatalf("expected unwrapped error to be nil, got %v", unwrapped)
 		}
 	})
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,338 @@
+package conc
+
+import (
+	"context"
+	"errors"
+	"iter"
+	"maps"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestSleep(t *testing.T) {
+	t.Run("respects duration", func(t *testing.T) {
+		ctx := context.Background()
+		start := time.Now()
+		Sleep(ctx, 100*time.Millisecond)
+		elapsed := time.Since(start)
+		if elapsed < 100*time.Millisecond {
+			t.Errorf("Sleep returned too early: got %v, want >= 100ms", elapsed)
+		}
+	})
+
+	t.Run("respects context cancellation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		start := time.Now()
+		go func() {
+			time.Sleep(50 * time.Millisecond)
+			cancel()
+		}()
+		Sleep(ctx, 1*time.Second)
+		elapsed := time.Since(start)
+		if elapsed >= 1*time.Second {
+			t.Errorf("Sleep didn't respect context cancellation: got %v, want < 1s", elapsed)
+		}
+	})
+}
+
+func TestAll(t *testing.T) {
+	t.Run("executes all jobs", func(t *testing.T) {
+		jobs := []Job[int]{
+			func(ctx context.Context) (int, error) { return 1, nil },
+			func(ctx context.Context) (int, error) { return 2, nil },
+			func(ctx context.Context) (int, error) { return 3, nil },
+		}
+
+		results, err := All(jobs)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		expected := []int{1, 2, 3}
+		if !reflect.DeepEqual(results, expected) {
+			t.Errorf("got %v, want %v", results, expected)
+		}
+	})
+
+	t.Run("handles errors", func(t *testing.T) {
+		expectedErr := errors.New("test error")
+		jobs := []Job[int]{
+			func(ctx context.Context) (int, error) { return 1, nil },
+			func(ctx context.Context) (int, error) { return 0, expectedErr },
+			func(ctx context.Context) (int, error) { return 3, nil },
+		}
+
+		_, err := All(jobs)
+		if err == nil {
+			t.Error("expected error, got nil")
+		}
+	})
+}
+
+func TestRace(t *testing.T) {
+	t.Run("returns first result", func(t *testing.T) {
+		jobs := []Job[int]{
+			func(ctx context.Context) (int, error) {
+				time.Sleep(100 * time.Millisecond)
+				return 1, nil
+			},
+			func(ctx context.Context) (int, error) {
+				return 2, nil
+			},
+			func(ctx context.Context) (int, error) {
+				time.Sleep(200 * time.Millisecond)
+				return 3, nil
+			},
+		}
+
+		result, err := Race(jobs)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if result != 2 {
+			t.Errorf("got %v, want 2", result)
+		}
+	})
+
+	t.Run("handles errors", func(t *testing.T) {
+		expectedErr := errors.New("test error")
+		jobs := []Job[int]{
+			func(ctx context.Context) (int, error) {
+				time.Sleep(100 * time.Millisecond)
+				return 0, expectedErr
+			},
+			func(ctx context.Context) (int, error) {
+				return 2, nil
+			},
+		}
+
+		_, err := Race(jobs)
+		if err == nil {
+			t.Error("expected error, got nil")
+		}
+	})
+}
+
+func TestRange(t *testing.T) {
+	t.Run("processes all items", func(t *testing.T) {
+		numbers := []int{1, 2, 3}
+		processed := make([]bool, len(numbers))
+		remaining := make([]int, len(numbers))
+		copy(remaining, numbers)
+
+		seq := iter.Seq[int](
+			func(yield func(int) bool) {
+				for _, n := range remaining {
+					if !yield(n) {
+						return
+					}
+				}
+			},
+		)
+
+		err := Range(
+			seq,
+			func(ctx context.Context, n int) error {
+				processed[n-1] = true
+				return nil
+			},
+		)
+
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		for i, p := range processed {
+			if !p {
+				t.Errorf("item %d was not processed", i+1)
+			}
+		}
+	})
+
+	t.Run("handles errors", func(t *testing.T) {
+		expectedErr := errors.New("test error")
+		seq := iter.Seq[int](
+			func(yield func(int) bool) {
+				yield(1)
+			},
+		)
+
+		err := Range(seq, func(ctx context.Context, n int) error {
+			return expectedErr
+		})
+
+		if err == nil {
+			t.Error("expected error, got nil")
+		}
+	})
+}
+
+func TestRange2(t *testing.T) {
+	t.Run("processes all items", func(t *testing.T) {
+		items := map[string]int{"a": 1, "b": 2, "c": 3}
+		processed := make(map[string]bool)
+
+		seq := iter.Seq2[string, int](
+			func(yield func(string, int) bool) {
+				for k, v := range items {
+					if !yield(k, v) {
+						return
+					}
+				}
+			},
+		)
+
+		err := Range2(
+			seq,
+			func(ctx context.Context, k string, v int) error {
+				processed[k] = true
+				return nil
+			},
+		)
+
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		expected := map[string]bool{"a": true, "b": true, "c": true}
+		if !reflect.DeepEqual(processed, expected) {
+			t.Errorf("got %v, want %v", processed, expected)
+		}
+	})
+}
+
+func TestMap(t *testing.T) {
+	t.Run("maps all items", func(t *testing.T) {
+		input := []int{1, 2, 3}
+		results, err := Map(
+			input,
+			func(ctx context.Context, n int) (int, error) {
+				return n * 2, nil
+			},
+		)
+
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		expected := []int{2, 4, 6}
+		if !reflect.DeepEqual(results, expected) {
+			t.Errorf("got %v, want %v", results, expected)
+		}
+	})
+
+	t.Run("handles errors", func(t *testing.T) {
+		input := []int{1, 2, 3}
+		expectedErr := errors.New("test error")
+		_, err := Map(
+			input,
+			func(ctx context.Context, n int) (int, error) {
+				if n == 2 {
+					return 0, expectedErr
+				}
+				return n * 2, nil
+			},
+		)
+
+		if err == nil {
+			t.Error("expected error, got nil")
+		}
+	})
+}
+
+func TestMapInPlace(t *testing.T) {
+	t.Run("maps all items in place", func(t *testing.T) {
+		input := []int{1, 2, 3}
+		results, err := MapInPlace(
+			input,
+			func(ctx context.Context, n int) (int, error) {
+				return n * 2, nil
+			},
+		)
+
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		expected := []int{2, 4, 6}
+		if !reflect.DeepEqual(results, expected) {
+			t.Errorf("got %v, want %v", results, expected)
+		}
+
+		// Verify it's the same slice
+		if &input[0] != &results[0] {
+			t.Error("MapInPlace created new slice instead of modifying in place")
+		}
+	})
+}
+
+func TestMap2(t *testing.T) {
+	t.Run("maps all items", func(t *testing.T) {
+		input := map[string]int{"a": 1, "b": 2, "c": 3}
+		results, err := Map2(
+			input,
+			func(ctx context.Context, k string, v int) (string, int, error) {
+				return k + k, v * 2, nil
+			},
+		)
+
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		expected := map[string]int{"aa": 2, "bb": 4, "cc": 6}
+		if !reflect.DeepEqual(results, expected) {
+			t.Errorf("got %v, want %v", results, expected)
+		}
+	})
+
+	t.Run("handles errors", func(t *testing.T) {
+		input := map[string]int{"a": 1, "b": 2}
+		expectedErr := errors.New("test error")
+		_, err := Map2(
+			input,
+			func(ctx context.Context, k string, v int) (string, int, error) {
+				if k == "b" {
+					return "", 0, expectedErr
+				}
+				return k + k, v * 2, nil
+			},
+		)
+
+		if err == nil {
+			t.Error("expected error, got nil")
+		}
+	})
+}
+
+func TestMap2InPlace(t *testing.T) {
+	t.Run("maps all items in place", func(t *testing.T) {
+		input := map[string]int{"a": 1, "b": 2, "c": 3}
+		originalInput := maps.Clone(input)
+
+		results, err := Map2InPlace(
+			input,
+			func(ctx context.Context, k string, v int) (string, int, error) {
+				return k, v * 2, nil
+			},
+		)
+
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		expected := map[string]int{"a": 2, "b": 4, "c": 6}
+		if !reflect.DeepEqual(results, expected) {
+			t.Errorf("got %v, want %v", results, expected)
+		}
+
+		// Verify the input map was modified
+		if reflect.DeepEqual(input, originalInput) {
+			t.Error("Map2InPlace did not modify the input map")
+		}
+		if !reflect.DeepEqual(input, expected) {
+			t.Error("Map2InPlace did not correctly modify the input map")
+		}
+	})
+}


### PR DESCRIPTION
Mostly just a "dotting i's and crossing t's" change. More elaborate tests can be added later, but this should be a good start.